### PR TITLE
Revert "Send the user language to the server, in order to get translated messages and emails."

### DIFF
--- a/enrollment.js
+++ b/enrollment.js
@@ -4,10 +4,6 @@
     if (typeof value !== kind) throw(name + " must be a " + kind + ".");
   }
 
-  function language () {
-    return navigator.language || navigator.userLanguage;
-  }
-
   function enroll(authKey, params, sucessCallback, errorCallback) {
     validateParam(authKey, "string", "authKey");
     validateParam(params, "object", "params");
@@ -34,7 +30,6 @@
 
     req.open("POST", "http://localhost:9292/classes/enroll");
     req.setRequestHeader('Content-Type', 'application/json');
-    req.setRequestHeader('Accept-Language', language());
     req.send(JSON.stringify(params));
   }
 


### PR DESCRIPTION
Reverts EasyEdu/enrollment.js#5

Because, browsers send the Accept-Language header automatically on ajax requests 